### PR TITLE
Fix for second contract query

### DIFF
--- a/handoff/second-contract/src/contract.rs
+++ b/handoff/second-contract/src/contract.rs
@@ -75,7 +75,7 @@ fn migrate<S: Storage, A: Api, Q: Querier>(
     let _response: ExportData = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
         contract_addr: state.first_contract_addr,
         callback_code_hash: state.first_contract_hash,
-        msg: to_binary(&FirstContractQueryMsg::Migrate { secret })?,
+        msg: to_binary(&FirstContractQueryMsg::ExportedData { secret })?,
     }))?;
 
     // TODO store the exported data in this contract's state.

--- a/handoff/second-contract/src/msg.rs
+++ b/handoff/second-contract/src/msg.rs
@@ -22,5 +22,5 @@ pub enum QueryMsg {}
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FirstContractQueryMsg {
-    Migrate { secret: Binary },
+    ExportedData { secret: Binary },
 }


### PR DESCRIPTION
The first contract in this example expects to queried with ExportedData{secret} from the second contract to migrate contract data.